### PR TITLE
Add HalfSBS and HighRefreshMode (120Hz) modes for Rokid Max

### DIFF
--- a/examples/set_to_3d.rs
+++ b/examples/set_to_3d.rs
@@ -23,10 +23,17 @@ enum CliDisplayMode {
     /// Picture should be same for both eyes (simple full HD mode)
     #[value(name("2d"), alias("same-on-both"))]
     SameOnBoth = 0,
-    /// Set display to 3840*1080, where the left half is the left eye, the right half
-    /// is the right eye
+    /// Set display to 3840*1080 or 3840*1200,
+    /// where the left half is the left eye, the right half is the right eye
     #[value(name("3d"), alias("sbs"), alias("stereo"))]
     Stereo = 1,
+    /// Set display to half-SBS mode, which presents itsefl as 1920*1080 resolution,
+    /// but actually scales down everything to 960x540,then upscales to 3840x1080
+    #[value(name("halfsbs"), alias("sbs2"), alias("half-stereo"))] // "sbs2" matches how half-SBS referred to in stereo3d filter in mpv player
+    HalfSBS = 2,
+    /// Set display to high refrash rate mode (typically 120Hz)
+    #[value(name("120hz"), alias("high-refresh-rate"))]
+    HighRefreshRate = 3,
 }
 
 fn main() {
@@ -42,6 +49,8 @@ fn main() {
         .set_display_mode(match args.mode {
             CliDisplayMode::SameOnBoth => DisplayMode::SameOnBoth,
             CliDisplayMode::Stereo => DisplayMode::Stereo,
+            CliDisplayMode::HalfSBS => DisplayMode::HalfSBS,
+            CliDisplayMode::HighRefreshRate => DisplayMode::HighRefreshRate,
         })
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,14 @@ pub struct SensorData3D {
 pub enum DisplayMode {
     /// Picture should be same for both eyes (simple full HD mode)
     SameOnBoth = 0,
-    /// Set display to 3840*1080, where the left half is the left eye, the right half
-    /// is the right eye
+    /// Set display to 3840*1080 or 3840x1200,
+    /// where the left half is the left eye, the right half is the right eye
     Stereo = 1,
+    /// Set display to half-SBS mode, which presents itsefl as 1920*1080 resolution,
+    /// but actually scales down everything to 960x540,then upscales to 3840x1080
+    HalfSBS = 2,
+    /// Set display to high refrash rate mode (typically 120Hz)
+    HighRefreshRate = 3,
 }
 
 /// Common interface for AR implemented glasses

--- a/src/nreal.rs
+++ b/src/nreal.rs
@@ -70,8 +70,11 @@ impl ARGlasses for NrealLight {
     fn set_display_mode(&mut self, display_mode: DisplayMode) -> Result<()> {
         let display_mode_byte = match display_mode {
             DisplayMode::SameOnBoth => b'1',
+            DisplayMode::HalfSBS => b'2',
             // This could be 4 for 72Hz, but I don't trust that mode
             DisplayMode::Stereo => b'3',
+            // Nreal doesn't have HighRefreshRate, so map it to the SameOnBoth value
+            DisplayMode::HighRefreshRate => b'1',
         };
         let result = self.run_command(Packet {
             category: b'1',

--- a/src/rokid.rs
+++ b/src/rokid.rs
@@ -121,8 +121,10 @@ impl ARGlasses for RokidAir {
         )?;
         if result[1] == 0 {
             Ok(DisplayMode::SameOnBoth)
-        } else {
+        } else if result[1] == 1 {
             Ok(DisplayMode::Stereo)
+        } else {
+            Ok(DisplayMode::HighRefreshRate)
         }
     }
 


### PR DESCRIPTION
I can switch with this library to 3D mode, but I could not find a way to switch back to the 2D high refresh rate mode, or to halfSBS mode, so I wrote this patch to add support for these modes.