### PR TITLE
Add support for Air 2 and Air 2 Pro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@ pub enum Error {
     SerialPortError(serialport::Error),
     /// No glasses were found.
     NotFound,
+    /// The feature is not available with this headset.
+    NotImplemented,
     /// Packet sending or reception timed out. Note that this is not the only
     /// timeout error that is sent (e.g. UsbError can contain a timeout), and
     /// also this is usually a fatal one.
@@ -101,6 +103,7 @@ impl std::fmt::Display for Error {
             #[cfg(feature = "serialport")]
             Error::SerialPortError(_) => "Serial error",
             Error::NotFound => "Glasses not found",
+            Error::NotImplemented => "Not implemented for these glasses",
             Error::PacketTimeout => "Packet timeout",
             Error::Other(s) => s,
         })
@@ -199,6 +202,10 @@ pub trait ARGlasses: Send {
     fn cameras(&self) -> Result<Vec<CameraDescriptor>> {
         Ok(Vec::new())
     }
+    /// Get the available display matrices
+    fn display_matrices(&self) -> Result<(DisplayMatrices, DisplayMatrices)> {
+        Err(Error::NotImplemented)
+    }
     /// The additional delay (in usecs) of the glasses' display from getting the data
     /// on DisplayPort. This is not really an absolute value, but more of
     /// a relative measure between different glasses.
@@ -223,6 +230,17 @@ pub struct CameraDescriptor {
     pub stereo_rotation: UnitQuaternion<f64>,
     /// Transformation from the IMU frame to the camera frame
     pub imu_to_camera: Isometry3<f64>,
+}
+
+/// Represents the decomposed extrinsic and intrinsic matrices for the display's lens.
+#[derive(Debug, Clone)]
+pub struct DisplayMatrices {
+    /// The intrinsic matrix of the display
+    pub intrinsic_matrix: Matrix3<f64>,
+    /// Native resolution of the display, in pixels.
+    pub resolution: (u32, u32),
+    /// Extrinsic matrix of the display; translation in meters.
+    pub isometry: Isometry3<f64>,
 }
 
 /// Convenience function to detect and connect to any of the supported glasses


### PR DESCRIPTION
I added the necessary code to detect and connect to the Air 2 and Air 2 Pro headsets (I didn't personally test but I had some of my users test it).

Since I don't have the hardware, I wanted to try to utilize the on-board config JSON to calculate the lens parameters. I know you said in Discord that you found them pretty inaccurate, but I did a comparison using the hand-calibrated values and what's on my device, and I found the results imperceptibly different. A few things to note:

- I had to customize the projection matrix based on the K matrix included. The main issue here is the off-center principal point in the matrix, which is effectively a translation of the lens.
- The on-board config data is weirdly translated, putting the right eye near x = 0. I compensate for the translation in the driver by centering them on the origin. It would probably be better to also rotate the values so that they fall on the x axis, but the difference is small.
- There's also a lens distortion array in the config JSON. The format is straightforward, it's an 18x32 list of (sx, sy, dx, dy) tuples, where sx, sy is a point on the device's screen and dx, dy is the linear distortion at that point. I haven't attempted to use this, so this is just a point of interest for future work.