### PR TITLE
nreal_air: fix HID writes on Windows + minor warning cleanup

### DIFF
--- a/src/nreal_air.rs
+++ b/src/nreal_air.rs
@@ -284,17 +284,17 @@ impl NrealAir {
     }
 
     fn run_command(&mut self, command: McuPacket) -> Result<Vec<u8>> {
-        self.device.write(
-            &command
-                .serialize()
-                .ok_or(Error::Other("Packet serialization failed"))?,
-        )?;
+        let expected_cmd_id = command.cmd_id;
+        let packet = command
+            .serialize()
+            .ok_or(Error::Other("Packet serialization failed"))?;
+        write_hid_packet(&self.device, &packet)?;
 
         for _ in 0..64 {
             let packet = self
                 .read_packet(COMMAND_TIMEOUT)?
                 .ok_or(Error::PacketTimeout)?;
-            if packet.cmd_id == command.cmd_id {
+            if packet.cmd_id == expected_cmd_id {
                 return Ok(packet.data);
             }
             self.pending_packets.push_back(packet);
@@ -429,14 +429,13 @@ impl ImuDevice {
     }
 
     fn command(&self, cmd_id: u8, data: &[u8]) -> Result<Vec<u8>> {
-        self.device.write(
-            &ImuPacket {
-                cmd_id,
-                data: data.into(),
-            }
-            .serialize()
-            .ok_or(Error::Other("Couldn't get acknowledgement to command"))?,
-        )?;
+        let command = ImuPacket {
+            cmd_id,
+            data: data.into(),
+        }
+        .serialize()
+        .ok_or(Error::Other("Couldn't get acknowledgement to command"))?;
+        write_hid_packet(&self.device, &command)?;
         let packet_size = self.model.imu_packet_size();
         for _ in 0..64 {
             let mut data = vec![0u8; packet_size];
@@ -672,4 +671,20 @@ fn open_nreal_air() -> Result<(AirModel, HidDevice, HidDevice)> {
     let imu = imu_device.ok_or(Error::NotFound)?;
 
     Ok((model, mcu, imu))
+}
+
+#[cfg(target_os = "windows")]
+fn write_hid_packet(device: &HidDevice, payload: &[u8; 0x40]) -> Result<()> {
+    // Windows HID writes need the leading report ID byte even for unnumbered reports.
+    // The Air replies on interfaces 3/4 once the payload is sent as [0x00 | 64-byte packet].
+    let mut report = [0u8; 0x41];
+    report[1..].copy_from_slice(payload);
+    device.write(&report)?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn write_hid_packet(device: &HidDevice, payload: &[u8; 0x40]) -> Result<()> {
+    device.write(payload)?;
+    Ok(())
 }

--- a/src/nreal_light.rs
+++ b/src/nreal_light.rs
@@ -642,7 +642,7 @@ impl NrealLightSlamCamera {
         Self::new_common(get_device_vid_pid(NrealLight::OV580_VID, NrealLight::OV580_PID)?.open()?)
     }
 
-    fn new_common(mut device_handle: rusb::DeviceHandle<rusb::GlobalContext>) -> Result<Self> {
+    fn new_common(device_handle: rusb::DeviceHandle<rusb::GlobalContext>) -> Result<Self> {
         const UVC_SET_CUR: u8 = 0x01;
         const UVC_VS_COMMIT_CONTROL: u16 = 0x02;
         device_handle.set_auto_detach_kernel_driver(true)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,6 +23,7 @@ pub fn get_device_vid_pid(vid: u16, pid: u16) -> Result<Device<GlobalContext>> {
 }
 
 #[cfg(feature = "rusb")]
+#[allow(dead_code)]
 pub fn get_interface_for_endpoint(
     device: &Device<GlobalContext>,
     endpoint_address: u8,


### PR DESCRIPTION
Fixes #13 

The problem seems to be that on windows you need to send a leading HID report ID byte 0x00.

Works for me on air under windows.